### PR TITLE
Add onDelete CASCADE to notification key on chats and chat rooms

### DIFF
--- a/prisma/prisma-datamodel.graphql
+++ b/prisma/prisma-datamodel.graphql
@@ -64,7 +64,7 @@ type Chat {
   message: String!
   createdAt: DateTime! @createdAt
   room: ChatRoom @relation(name: "Room")
-  notification: [Notification]! @relation(name: "ChatNotification")
+  notification: [Notification]! @relation(name: "ChatNotification", onDelete: CASCADE)
 }
 
 type ChatRoom {
@@ -80,7 +80,7 @@ type Announcement {
   message: String!
   createdAt: DateTime! @createdAt
   isAnnouncementRoom: Boolean! 
-  notification: [Notification]! @relation(name: "AnnouncementNotification")
+  notification: [Notification]! @relation(name: "AnnouncementNotification", onDelete: CASCADE)
 }
 
 type Notification {


### PR DESCRIPTION
# Description

Resolve issue where deleted chat rooms kept notifications on side nav

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

- [x] GraphQL playground

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
